### PR TITLE
LEN-4006: Detect when Cborg is invalid

### DIFF
--- a/cborg/CborgHeader.h
+++ b/cborg/CborgHeader.h
@@ -32,8 +32,8 @@ public:
     {
         // reset variables
         tag = 0xFF;
-        majorType = CborBase::TypeSpecial;
-        minorType = CborBase::TypeNull;
+        majorType = CborBase::TypeUnassigned;
+        minorType = CborBase::TypeUnknown;
         length = 0;
         value = 0;
 


### PR DESCRIPTION
Before this change, the cborg library would return `major`/`minor` type of `TypeSpecial`/`TypeNull` for invalid state. However, that is also the return value for a valid CBOR value. This changes the return in this situation to `TypeUnassigned`/`TypeUnknown`, which is an invalid value type.