### PR TITLE
LEN-5680: Support for 64-bit floats and empty arrays

### DIFF
--- a/cborg/CborgHeader.h
+++ b/cborg/CborgHeader.h
@@ -92,6 +92,24 @@ public:
 
                 length = 5;
             }
+            else if (minorType == 27) // 8 bytes
+            {
+                if (maxLength < 9)
+                {
+                    return;
+                }
+
+                value = ((uint64_t) head[1] << 56)
+                      | ((uint64_t) head[2] << 48)
+                      | ((uint64_t) head[3] << 40)
+                      | ((uint64_t) head[4] << 32)
+                      | ((uint64_t) head[5] << 24)
+                      | ((uint64_t) head[6] << 16)
+                      | ((uint64_t) head[7] << 8)
+                      |             head[8];
+
+                length = 9;
+            }
             else if (minorType == CborBase::TypeIndefinite)
             {
                 value = 31;
@@ -154,6 +172,23 @@ public:
                           | ((uint32_t) head[length + 3] << 8)
                           |             head[length + 4];
                     length += 5;
+                }
+                else if (minorType == 27)
+                {
+                    if (maxLength < uint32_t(length) + 9)
+                    {
+                        return;
+                    }
+
+                    value = ((uint64_t) head[length + 1] << 56)
+                          | ((uint64_t) head[length + 2] << 48)
+                          | ((uint64_t) head[length + 3] << 40)
+                          | ((uint64_t) head[length + 4] << 32)
+                          | ((uint64_t) head[length + 5] << 24)
+                          | ((uint64_t) head[length + 6] << 16)
+                          | ((uint64_t) head[length + 7] << 8)
+                          |             head[length + 8];
+                    length += 9;
                 }
                 else if (minorType == CborBase::TypeIndefinite)
                 {

--- a/source/Cborg.cpp
+++ b/source/Cborg.cpp
@@ -123,7 +123,7 @@ bool Cborg::getCBOR(const uint8_t** pointer, uint32_t* length)
                 {
                     list.push_back(units);
                     units = 2 * head.getValue();
-                } else if (units == maxOf(units)) {
+                } else if (units == maxOf(units) && head.getLength() == 0) {
                     // We're not making progress. We'll just process the current unit
                     // endlessly. Something is wrong. We need to bail.
                     return false;
@@ -140,7 +140,7 @@ bool Cborg::getCBOR(const uint8_t** pointer, uint32_t* length)
                 {
                     list.push_back(units);
                     units = head.getValue();
-                } else if (units == maxOf(units)) {
+                } else if (units == maxOf(units) && head.getLength() == 0) {
                     // We're not making progress. We'll just process the current unit
                     // endlessly. Something is wrong. We need to bail.
                     return false;
@@ -284,7 +284,7 @@ uint32_t Cborg::getCBORLength()
                 {
                     list.push_back(units);
                     units = 2 * head.getValue();
-                } else if (units == maxOf(units)) {
+                } else if (units == maxOf(units) && head.getLength() == 0) {
                     // We're not making progress. We'll just process the current unit
                     // endlessly. Something is wrong. We need to bail.
                     return false;
@@ -301,7 +301,7 @@ uint32_t Cborg::getCBORLength()
                 {
                     list.push_back(units);
                     units = head.getValue();
-                } else if (units == maxOf(units)) {
+                } else if (units == maxOf(units) && head.getLength() == 0) {
                     // We're not making progress. We'll just process the current unit
                     // endlessly. Something is wrong. We need to bail.
                     return false;
@@ -428,7 +428,7 @@ Cborg Cborg::find(int32_t key) const
             {
                 list.push_back(units);
                 units = 2 * head.getValue();
-            } else if (units == maxOf(units)) {
+            } else if (units == maxOf(units) && head.getLength() == 0) {
                 // We're not making progress. We'll just process the current unit
                 // endlessly. Something is wrong. We need to bail.
                 return Cborg(NULL, 0);
@@ -447,7 +447,7 @@ Cborg Cborg::find(int32_t key) const
             {
                 list.push_back(units);
                 units = head.getValue();
-            } else if (units == maxOf(units)) {
+            } else if (units == maxOf(units) && head.getLength() == 0) {
                 // We're not making progress. We'll just process the current unit
                 // endlessly. Something is wrong. We need to bail.
                 return Cborg(NULL, 0);
@@ -614,7 +614,7 @@ Cborg Cborg::find(const char* key, std::size_t keyLength) const
             {
                 list.push_back(units);
                 units = 2 * head.getValue();
-            } else if (units == maxOf(units)) {
+            } else if (units == maxOf(units) && head.getLength() == 0) {
                 // We're not making progress. We'll just process the current unit
                 // endlessly. Something is wrong. We need to bail.
                 return Cborg(NULL, 0);
@@ -633,7 +633,7 @@ Cborg Cborg::find(const char* key, std::size_t keyLength) const
             {
                 list.push_back(units);
                 units = head.getValue();
-            } else if (units == maxOf(units)) {
+            } else if (units == maxOf(units) && head.getLength() == 0) {
                 // We're not making progress. We'll just process the current unit
                 // endlessly. Something is wrong. We need to bail.
                 return Cborg(NULL, 0);
@@ -814,7 +814,7 @@ Cborg Cborg::getKey(std::size_t index) const
                 {
                     list.push_back(units);
                     units = 2 * head.getValue();
-                } else if (units == maxOf(units)) {
+                } else if (units == maxOf(units) && head.getLength() == 0) {
                     // We're not making progress. We'll just process the current unit
                     // endlessly. Something is wrong. We need to bail.
                     return Cborg(NULL, 0);
@@ -831,7 +831,7 @@ Cborg Cborg::getKey(std::size_t index) const
                 {
                     list.push_back(units);
                     units = head.getValue();
-                } else if (units == maxOf(units)) {
+                } else if (units == maxOf(units) && head.getLength() == 0) {
                     // We're not making progress. We'll just process the current unit
                     // endlessly. Something is wrong. We need to bail.
                     return Cborg(NULL, 0);
@@ -962,7 +962,7 @@ Cborg Cborg::at(std::size_t index) const
                 {
                     list.push_back(units);
                     units = 2 * head.getValue();
-                } else if (units == maxOf(units)) {
+                } else if (units == maxOf(units) && head.getLength() == 0) {
                     // We're not making progress. We'll just process the current unit
                     // endlessly. Something is wrong. We need to bail.
                     return Cborg(NULL, 0);
@@ -979,7 +979,7 @@ Cborg Cborg::at(std::size_t index) const
                 {
                     list.push_back(units);
                     units = head.getValue();
-                } else if (units == maxOf(units)) {
+                } else if (units == maxOf(units) && head.getLength() == 0) {
                     // We're not making progress. We'll just process the current unit
                     // endlessly. Something is wrong. We need to bail.
                     return Cborg(NULL, 0);
@@ -1274,7 +1274,7 @@ void Cborg::print() const
 
                 list.push_back(units);
                 units = 2 * head.getValue();
-            } else if (units == maxOf(units)) {
+            } else if (units == maxOf(units) && head.getLength() == 0) {
                 // We're not making progress. We'll just process the current unit
                 // endlessly. Something is wrong. We need to bail.
                 return;
@@ -1295,7 +1295,7 @@ void Cborg::print() const
 
                 list.push_back(units);
                 units = head.getValue();
-            } else if (units == maxOf(units)) {
+            } else if (units == maxOf(units) && head.getLength() == 0) {
                 // We're not making progress. We'll just process the current unit
                 // endlessly. Something is wrong. We need to bail.
                 return;


### PR DESCRIPTION
This is part of a fuzzer fix. As part of that fix, it turns out that `cborg` doesn't properly support:

* 64-bit floating point numbers
* Zero-length arrays and maps

These changes fix both issues.

> NOTE: This is part one of the fuzzer fix. Part two is a change to the C2PA repo, but that change is dependent on this one, so this must be merged first.